### PR TITLE
ci: add ci(for `build` & `test)

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,69 @@
+name: Build and Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch: # For manual execution.
+
+env:
+  build-mode: Debug # Release | Debug
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages # Prevent extra cache by specifying.
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        dotnet-version: ["8.0.x"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.NUGET_PACKAGES }}
+            */bin
+            */obj
+          key: nuget-${{ matrix.os }}-${{ matrix.dotnet-version }}
+          restore-keys: nuget-${{ matrix.os }}-
+
+      - name: Build
+        run: dotnet build "./HKX2ELibrary.sln" --configuration ${{ env.build-mode }}
+
+  test:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        dotnet-version: ["8.0.x"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.NUGET_PACKAGES }}
+            */bin
+            */obj
+          key: nuget-${{ matrix.os }}-${{ matrix.dotnet-version }}
+          restore-keys: nuget-${{ matrix.os }}-
+
+      - name: Test
+        run: dotnet test "./HKX2ELibrary.sln" --configuration ${{ env.build-mode }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
+      # Ref: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows
       - name: Restore cache
         uses: actions/cache@v4
         with:
@@ -66,4 +67,6 @@ jobs:
           restore-keys: nuget-${{ matrix.os }}-
 
       - name: Test
-        run: dotnet test "./HKX2ELibrary.sln" --configuration ${{ env.build-mode }}
+        # NOTE: Exclude tests for debugging purposes that error using `~!`.
+        # `!~` is `doesn't contain`: https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest#syntax
+        run: dotnet test --filter "FullyQualifiedName!~HKX2E.Tests.CompareTests" --configuration ${{ env.build-mode }}

--- a/HKX2/BinaryReaderEx.cs
+++ b/HKX2/BinaryReaderEx.cs
@@ -270,9 +270,21 @@ namespace HKX2E
 
         public Half ReadHalf()
         {
+            /// NOTE: C++'s `hkHalf` is the upper 16 bits of `float` and does not follow IEEE 754.
+            /// However, this library has already been designed using `System.Half`, so it is necessary not to break compatibility.
+            /// Therefore, we should do `bytes` -> `float` -> `half` here to keep compatibility.
+            ///
+            /// - Evidence that `System.Half` is IEEE 754: https://learn.microsoft.com/en-us/dotnet/api/system.half?view=net-8.0#remarks
+            byte[] byteArray;
+
             if (BigEndian)
-                return BitConverter.ToHalf(ReadReversedBytes(2), 0);
-            return br.ReadHalf();
+                byteArray = ReadReversedBytes(2);
+            else
+                byteArray = ReadBytes(2);
+
+            ushort halfBits = BitConverter.ToUInt16(byteArray, 0);
+            float floatValue = BitConverter.UInt32BitsToSingle((uint)halfBits << 16);
+            return (Half)floatValue;
         }
 
         public Half AssertHalf(params Half[] options)

--- a/HKX2/BinaryWriterEx.cs
+++ b/HKX2/BinaryWriterEx.cs
@@ -331,10 +331,16 @@ namespace HKX2E
 
         public void WriteHalf(Half value)
         {
+            /// NOTE: C++'s `hkHalf` is the upper 16 bits of `float` and does not follow IEEE754.
+            /// However, this library has already been designed using `System.Half`, so it is necessary not to break compatibility.
+            /// Therefore, we should do `half` -> `float` -> `bytes` here to keep compatibility.
+            uint bits = BitConverter.SingleToUInt32Bits((float)value);
+            ushort halfBits = (ushort)(bits >> 16); // Only the most significant 16 bits are taken out.
+
             if (BigEndian)
-                WriteReversedBytes(BitConverter.GetBytes(value));
+                WriteReversedBytes(BitConverter.GetBytes(halfBits));
             else
-                bw.Write(value);
+                bw.Write(halfBits);
         }
 
         public void ReserveHalf(string name)

--- a/HKX2Tests/Utils/HalfTests.cs
+++ b/HKX2Tests/Utils/HalfTests.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HKX2E.Tests
+{
+    // Due to the `hkHalf` specification, the `Half` binary data handled by this library does not conform to IEEE 754,
+    // so write/read tests must be performed.
+    [TestClass]
+    public class HalfTests
+    {
+        enum Endianness
+        {
+            Little,
+            Big,
+        }
+
+        void AssertHalf(double from, byte[] expected, double to, Endianness endian)
+        {
+            var isBigEndian = Endianness.Big == endian;
+            var stream = new MemoryStream();
+            var bw = new BinaryWriterEx(isBigEndian, true, stream);
+            bw.WriteHalf((Half)from);
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            var bytes = stream.ToArray();
+            CollectionAssert.AreEqual(expected, bytes);
+
+            var br = new BinaryReaderEx(isBigEndian, true, stream);
+            var result = br.ReadHalf();
+            Assert.AreEqual((float)to, (float)result);
+        }
+
+        [TestMethod]
+        public void HalfToLEBytes()
+        {
+            // Use the value that actually appears.
+            // "Skyrim Special Edition\meshes\actors\wisp\character assets\skeleton.hkx"
+            // 00006090: 8e 49 24 41 00 00 4c 3d 80 3f 7f 7f 02 00 00 00  .I$A..L=.?......
+            //                                   |----| <- m_timeFactor: 1.000000
+            //                             |----| <- angularDamping: 0x3c4c
+            //
+            //angularDamping: 0x3c4c
+            // -> float: 0.498046875 -> 0.049804688(The precision will be lost)
+            // -> ToXML: 0.049805(The sixth decimal point is rounded off, resulting in a loss of precision)
+
+            AssertHalf(1.0, [0x80, 0x3F], 1.0, Endianness.Little);
+            AssertHalf(0.049805, [0x4c, 0x3d], 0.049804688, Endianness.Little);
+        }
+
+        [TestMethod]
+        public void HalfToBEBytes()
+        {
+            AssertHalf(1.0, [0x3F, 0x80], 1.0, Endianness.Big);
+            AssertHalf(0.049805, [0x3d, 0x4c], 0.049804688, Endianness.Big);
+        }
+    }
+}

--- a/HKX2Tests/Utils/HalfTests.cs
+++ b/HKX2Tests/Utils/HalfTests.cs
@@ -37,9 +37,9 @@ namespace HKX2E.Tests
             // "Skyrim Special Edition\meshes\actors\wisp\character assets\skeleton.hkx"
             // 00006090: 8e 49 24 41 00 00 4c 3d 80 3f 7f 7f 02 00 00 00  .I$A..L=.?......
             //                                   |----| <- m_timeFactor: 1.000000
-            //                             |----| <- angularDamping: 0x3c4c
+            //                             |----| <- angularDamping: 0.498046875
             //
-            //angularDamping: 0x3c4c
+            //angularDamping: 0x3d4c0000
             // -> float: 0.498046875 -> 0.049804688(The precision will be lost)
             // -> ToXML: 0.049805(The sixth decimal point is rounded off, resulting in a loss of precision)
 


### PR DESCRIPTION
While investigating a strange discrepancy in `skeleton.hkx` during `serde-hkx` binary data reproduction, it was discovered that f16's handling of binary data does not follow IEEE 754, and the results of that research are provided here.

# Test
```txt
Tested using values extracted from actual hkx data.
"Skyrim Special Edition\meshes\actors\wisp\character assets\skeleton.hkx"
00006090: 8e 49 24 41 00 00 4c 3d 80 3f 7f 7f 02 00 00 00  .I$A..L=.?......
                                  |----| <- m_timeFactor(f16): 1.000000
                            |----| <- angularDamping(f16): 0.498046875

hkMotionState.angularDamping: 0x3d4c0000
-> float: 0.498046875 -> 0.049804688(The precision will be lost)
-> ToXML: 0.049805(The sixth decimal point is rounded off, resulting in a loss of precision)
```

# How was it before?
I can confirm that the binary data for Half was wrong before because the test failed on the commit that added only CI and test.
[Failed log](https://github.com/SARDONYX-forks/HKX2-Enhanced-Library/actions/runs/10604290008/job/29390594087#step:5:88)

# This commit.
It passes the test with the actual hkx binary data.
[Ok log](https://github.com/SARDONYX-forks/HKX2-Enhanced-Library/actions/runs/10604318290/job/29390699844)
